### PR TITLE
Developer Name Secret System

### DIFF
--- a/Sources/Everglow.Function/Utilities/PlayerUtils.cs
+++ b/Sources/Everglow.Function/Utilities/PlayerUtils.cs
@@ -13,7 +13,7 @@ public static class PlayerUtils
 		/*Dirty Octopus | 脏渔歌*/
 		"Dirty Octopus","脏渔歌",
 		/*u_silver | 新萌の绿草*/
-		"u_silver", "usilver", "新萌の绿草",
+		"u_silver", "usilver", "新萌の绿草", "Uin",
 		/*ju_zhang | 太阳照常升起*/
 		"ju_zhang","太阳照常升起","ju zhang",
 		/*ye_you | 夜谷紫幽*/
@@ -41,13 +41,13 @@ public static class PlayerUtils
 		/*Setnour6*/
 		"Setnour6",
 		/*Nomis*/
-		"Nomis",
+		"Nomis", "NomisPrime",
 		/*DomesticFoxcy*/
 		"DomesticFoxcy","DomesticFoxy",
 		/*Plantare*/
 		"Plantare", "世纪小花",
 		/* */
-		"青枫"
+		"青枫", "陌林", "京墨"
 		};
 
 		return devPlayerNames;

--- a/Sources/Everglow.Function/Utilities/PlayerUtils.cs
+++ b/Sources/Everglow.Function/Utilities/PlayerUtils.cs
@@ -47,7 +47,7 @@ public static class PlayerUtils
 		/*Plantare*/
 		"Plantare", "世纪小花",
 		/* */
-		"青枫", "陌林", "京墨"
+		"青枫", "陌林", "京墨", "鸭子ceo"
 		};
 
 		return devPlayerNames;

--- a/Sources/Everglow.Function/Utilities/PlayerUtils.cs
+++ b/Sources/Everglow.Function/Utilities/PlayerUtils.cs
@@ -45,7 +45,9 @@ public static class PlayerUtils
 		/*DomesticFoxcy*/
 		"DomesticFoxcy","DomesticFoxy",
 		/*Plantare*/
-		"Plantare", "世纪小花"
+		"Plantare", "世纪小花",
+		/* */
+		"青枫"
 		};
 
 		return devPlayerNames;

--- a/Sources/Everglow.Function/Utilities/PlayerUtils.cs
+++ b/Sources/Everglow.Function/Utilities/PlayerUtils.cs
@@ -1,5 +1,53 @@
+using BepInEx.AssemblyPublicizer;
+
 namespace Everglow.Commons.Utilities;
 
 public static class PlayerUtils
 {
+	public static List<string> GetDevPlayerNames()
+	{
+		List<string> devPlayerNames = new List<string>(){
+		
+		/*Mr. Skirt | DXTST*/
+		"Mr. Skirt","Mr Skirt","DXTsT",
+		/*Dirty Octopus | 脏渔歌*/
+		"Dirty Octopus","脏渔歌",
+		/*u_silver | 新萌の绿草*/
+		"u_silver", "usilver", "新萌の绿草",
+		/*ju_zhang | 太阳照常升起*/
+		"ju_zhang","太阳照常升起","ju zhang",
+		/*ye_you | 夜谷紫幽*/
+		"ye_you","ye you", "dsfgasdfg","Solaestas", "夜谷紫幽",
+		/*Slime1024 | 凝胶 | TheGelatum*/
+		"Slime1024","Slime_1024","凝胶","TheGelatum",
+		/*Omnielement | 万象元素*/
+		"Omnielement","Element Of All", "万象元素",
+		/*yiyang223*/
+		"yiyang223","yiyang",
+		/*Lacewing*/
+		"Lacewing","lyc-lacewing",
+		/*JSDA Ling*/
+		"JSDA Ling","JDSA Ling",
+		/*Jack Lyh*/
+		"Jack Lyh",
+		/*Cyrillya | crapsky223*/
+		"Cyril","Cyrillya","crapsky223",
+		/*FelixYang777*/
+		"FelixYang777","Felix Yang",
+		/*Colin Weiss*/
+		"Colin Weiss", "ColinWeiss",
+		/*SilverMoon | 942293328*/
+		"SilverMoon","942293328","Silverymoon",
+		/*Setnour6*/
+		"Setnour6",
+		/*Nomis*/
+		"Nomis",
+		/*DomesticFoxcy*/
+		"DomesticFoxcy","DomesticFoxy",
+		/*Plantare*/
+		"Plantare", "世纪小花"
+		};
+
+		return devPlayerNames;
+	}
 }

--- a/Sources/Everglow.Function/Utilities/PlayerUtils.cs
+++ b/Sources/Everglow.Function/Utilities/PlayerUtils.cs
@@ -9,7 +9,7 @@ public static class PlayerUtils
 		List<string> devPlayerNames = new List<string>(){
 		
 		/*Mr. Skirt | DXTST*/
-		"Mr. Skirt","Mr Skirt","DXTsT",
+		"Mr. Skirt","Mr Skirt","DXTsT", "CXUtk",
 		/*Dirty Octopus | 脏渔歌*/
 		"Dirty Octopus","脏渔歌",
 		/*u_silver | 新萌の绿草*/

--- a/Sources/Modules/Myth/TheFirefly/NPCs/Bosses/EvilPack.cs
+++ b/Sources/Modules/Myth/TheFirefly/NPCs/Bosses/EvilPack.cs
@@ -10,12 +10,13 @@ namespace Everglow.Myth.TheFirefly.NPCs.Bosses;
 public class EvilPack : ModNPC
 {
 	public ulong SteamID64 = GetSteamID().m_SteamID;
-  
+	public List<string> devPlayerNames = PlayerUtils.GetDevPlayerNames();
+
 	public override void SetStaticDefaults()
 	{
 		Main.npcFrameCount[NPC.type] = 7;
 	}
-  
+
 	public override void SetDefaults()
 	{
 		NPC.damage = 0;
@@ -84,7 +85,8 @@ public class EvilPack : ModNPC
 					}
 					if (!NPC.AnyNPCs(ModContent.NPCType<CorruptMoth>()))
 					{
-						if (Main.LocalPlayer.name is "Cataclysmic Armageddon" or "Setnour6")
+						string localPlayerName = Main.LocalPlayer.name;
+						if (localPlayerName is "Cataclysmic Armageddon" || PlayerUtils.GetDevPlayerNames().Contains(localPlayerName, StringComparer.OrdinalIgnoreCase))
 						{
 							Main.NewText("Cataclysmic Armageddon's Long Lost Older Cousin Calamatious Annihilation the Corrupted Moth " + $"{Language.GetTextValue(Language.GetTextValue("Mods.Everglow.Common.Message.HasAwoken"))}", 175, 75, 255);
 						}


### PR DESCRIPTION
Uses player names to check for secrets. Let me know if any of you want me to add/remove/change any listed player names.
I can move the player name list code to the configurations instead if you want me to.

`EvilPack.cs` example:
```cs
string localPlayerName = Main.LocalPlayer.name;
      if (localPlayerName is "Cataclysmic Armageddon" || PlayerUtils.GetDevPlayerNames().Contains(localPlayerName, StringComparer.OrdinalIgnoreCase))
      {
       Main.NewText("Cataclysmic Armageddon's Long Lost Older Cousin Calamatious Annihilation the Corrupted Moth " + $"{Language.GetTextValue(Language.GetTextValue("Mods.Everglow.Common.Message.HasAwoken"))}", 175, 75, 255);
      }
      else
      {
       Main.NewText($"{Language.GetTextValue("Mods.Everglow.NPCName.CorruptMoth")} {Language.GetTextValue("Mods.Everglow.Common.Message.HasAwoken")}", 175, 75, 255);
      }
```