### PR TITLE
Hotfix/PickSound Hook Update

### DIFF
--- a/Sources/Everglow.Function/AssetReplace/IModifyItemPickSound.cs
+++ b/Sources/Everglow.Function/AssetReplace/IModifyItemPickSound.cs
@@ -7,7 +7,7 @@ namespace Everglow.Commons.AssetReplace
 {
 	public interface IModifyItemPickSound
 	{
-		public static readonly GlobalHookList<GlobalItem> Hook = ItemLoader.AddModHook(new GlobalHookList<GlobalItem>(typeof(Hook).GetMethod(nameof(ModifyItemPickSound))));
+		public static readonly GlobalHookList<GlobalItem> Hook = ItemLoader.AddModHook(GlobalHookList<GlobalItem>.Create(e => (e as Hook).ModifyItemPickSound));
 		/// <summary>
 		/// 用于替换掉从物品槽拿起/放下物品的音效（不会在服务器运行）
 		/// </summary>

--- a/Sources/Modules/SpellAndSkull/Projectiles/LunarFlare/LunarFlareArray.cs
+++ b/Sources/Modules/SpellAndSkull/Projectiles/LunarFlare/LunarFlareArray.cs
@@ -267,6 +267,8 @@ internal class StarrySkySystem : ModSystem
 		//绘制substar
 		stars.ForEach(star => star.Draw());
 		Main.spriteBatch.End();
+		graphicsDevice.SetRenderTarget(StarryTarget);
+		graphicsDevice.Clear(Color.Transparent);
 		Main.spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.AlphaBlend);
 
 
@@ -278,9 +280,7 @@ internal class StarrySkySystem : ModSystem
 		Starry.Parameters["uTime"].SetValue((float)(Main.timeForVisualEffects * 0.005f));
 		Starry.Parameters["tex1"].SetValue(StarrySkyTarget);
 		Starry.CurrentTechnique.Passes[0].Apply();
-
-		graphicsDevice.SetRenderTarget(StarryTarget);
-		graphicsDevice.Clear(Color.Transparent);
+		
 		Main.spriteBatch.Draw(blackTarget, Vector2.Zero, Color.White);
 
 		Main.spriteBatch.End();


### PR DESCRIPTION
This is for an upcoming 1.4.4 update (tModLoader/tModLoader#4089). I hope I did it right. I was able to get it tested and working.
This will be held as a draft until the stable/public build is updated with the new changes made there.

To test the changes in this PR, switch the branch to `hotfix/PickSound_HookUpdate` and add any item that uses `IModifyItemPickSound`, such as a healing potion, wood, gold bar, etc. Click on the item from your inventory repeatedly so the unique item pick sound can play over and over again.
The expected result is that the sound and function should not have any issues.