### PR TITLE
Common/collision source

### DIFF
--- a/Sources/Everglow.Function/Shapes/Shape.cs
+++ b/Sources/Everglow.Function/Shapes/Shape.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using static Everglow.Commons.Shapes.Shape;
 
 namespace Everglow.Commons.Shapes
@@ -90,6 +85,46 @@ namespace Everglow.Commons.Shapes
 				}
 			}
 		}
+		public virtual void Move(Vector2 movement)
+		{
+			Matrix transform = Matrix.CreateTranslation(new Vector3(movement, 0));
+			Transform(transform);
+		}
+		public virtual void Scale(Vector2? baseCenter, float scale)
+		{
+			if (baseCenter == null)
+			{
+				baseCenter = Vector2.Zero;
+				for (int i = 0; i < vertex.Length; i++)
+				{
+					baseCenter += vertex[i];
+				}
+				baseCenter /= vertex.Length;
+			}
+			Matrix transform = Matrix.CreateTranslation(new Vector3(baseCenter.Value, 0)) * Matrix.CreateScale(scale, scale, 1) * Matrix.CreateTranslation(new Vector3(-baseCenter.Value, 0));
+			Transform(transform);
+		}
+		public virtual void Rotate(Vector2? baseCenter, float radian)
+		{
+			if (baseCenter == null)
+			{
+				baseCenter = Vector2.Zero;
+				for (int i = 0; i < vertex.Length; i++)
+				{
+					baseCenter += vertex[i];
+				}
+				baseCenter /= vertex.Length;
+			}
+			Matrix transform = Matrix.CreateTranslation(new Vector3(baseCenter.Value, 0)) * Matrix.CreateRotationZ(radian) * Matrix.CreateTranslation(new Vector3(-baseCenter.Value, 0));
+			Transform(transform);
+		}
+		public virtual void Transform(Matrix transform)
+		{
+			for (int i = 0; i < vertex.Length; i++)
+			{
+				vertex[i] = Vector2.Transform(vertex[i], transform);
+			}
+		}
 	}
 	public class Circle : NormalConvex2D
 	{
@@ -145,6 +180,11 @@ namespace Everglow.Commons.Shapes
 					max = projection;
 				}
 			}
+		}
+		public override void Transform(Matrix transform)
+		{
+			base.Transform(transform);
+			Center = Vector2.Transform(Center, transform);
 		}
 	}
 	public class Triangle : NormalConvex2D

--- a/Sources/Everglow.Function/Shapes/Shape.cs
+++ b/Sources/Everglow.Function/Shapes/Shape.cs
@@ -21,7 +21,6 @@ namespace Everglow.Commons.Shapes
 		{
 			public ReadOnlySpan<T> ConvexVertex();
 		}
-	}
 	public class NormalConvex2D : IConvex<Vector2>, ISAT<Vector2>, IEPA<Vector2>
 	{
 		public static NormalConvex2D Create(Span<Vector2> vs)
@@ -261,5 +260,6 @@ namespace Everglow.Commons.Shapes
 		{
 			return new Microsoft.Xna.Framework.Rectangle((int)rect.vertex[0].X, (int)rect.vertex[0].Y, (int)rect.width, (int)rect.height);
 		}
+	}
 	}
 }

--- a/Sources/Everglow.Function/Shapes/Shape.cs
+++ b/Sources/Everglow.Function/Shapes/Shape.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static Everglow.Commons.Shapes.Shape;
+
+namespace Everglow.Commons.Shapes
+{
+	internal class Shape
+	{
+		public interface ISAT<T>
+		{
+			public List<T> GetAxes();
+			public void Project(T axis, out float min, out float max);
+		}
+		public interface IGJK<T>
+		{
+			public T FurthestPoint(T dir);
+		}
+		public interface IEPA<T>:IGJK<T>
+		{
+
+		}
+		public interface IConvex<T>
+		{
+			public ReadOnlySpan<T> ConvexVertex();
+		}
+	}
+	public class NormalConvex2D : IConvex<Vector2>, IEPA<Vector2>
+	{
+		public NormalConvex2D(IEnumerable<Vector2> vs)
+		{
+			vertex = ShapeCollision.QuickHull(vs).ToArray();
+		}
+		protected readonly Vector2[] vertex;
+		public ReadOnlySpan<Vector2> ConvexVertex()
+		{
+			return new ReadOnlySpan<Vector2>(vertex);
+		}
+		public Vector2 FurthestPoint(Vector2 dir)
+		{
+			Vector2 center = Vector2.Zero;
+			vertex.ForEach(v => center += v);
+			center /= vertex.Count;
+			Vector2 result = vertex[0];
+			Vector2 Vr = result - center;
+			float d = Vector2.Dot(Vr, dir);
+			for (int i = 1; i < vertex.Count; i++)
+			{
+				Vector2 Vi = vertex[i] - center;
+				float di = Vector2.Dot(Vi, dir);
+				if (di > d)
+				{
+					d = di;
+					result = vertex[i];
+				}
+			}
+			return result;
+		}
+	}
+	internal class Circle : IConvex<Vector2>, ISAT<Vector2>, IEPA<Vector2>
+	{
+		private uint samplingNumber = 8;
+		private float radius;
+		public Vector2 Center;
+		public uint SamplingNumber
+		{
+			get => samplingNumber;
+			set => samplingNumber = Math.Max(value, 3);
+		}
+		public float Radius
+		{
+			get => radius;
+			set => radius = Math.Max(value, float.Epsilon);
+		}
+		public ReadOnlySpan<Vector2> ConvexVertex()
+		{
+			Vector2[] result = new Vector2[samplingNumber];
+			for (int i = 0; i < samplingNumber; i++)
+			{
+				float f = MathHelper.TwoPi / samplingNumber * i;
+				result[i] = Center + new Vector2((float)Math.Cos(f), (float)Math.Sin(f)) * radius;
+			}
+			return new ReadOnlySpan<Vector2>(result);
+		}
+		public Vector2 FurthestPoint(Vector2 dir)
+		{
+			return Center + Vector2.Normalize(dir) * radius;
+		}
+		public List<Vector2> GetAxes()
+		{
+			var samplings = ConvexVertex();
+			List<Vector2> axes = new();
+			for (int i = 1; i < samplingNumber; i++)
+			{
+				axes.Add(samplings[i] - samplings[i - 1]);
+			}
+			axes.Add(samplings[0] - samplings[^1]);
+			return axes;
+		}
+		public void Project(Vector2 axis, out float min, out float max)
+		{
+			min = float.MaxValue;
+			max = float.MinValue;
+			foreach (Vector2 point in ConvexVertex())
+			{
+				float projection = Vector2.Dot(point, axis);
+				if (projection < min)
+				{
+					min = projection;
+				}
+				if (projection > max)
+				{
+					max = projection;
+				}
+			}
+		}
+		public static explicit operator NormalConvex2D(Circle circle)
+		{
+			return new NormalConvex2D(circle.ConvexVertex());
+		}
+	}
+	internal class Triangle : IConvex<Vector2>, ISAT<Vector2>, IEPA<Vector2>
+	{
+		private readonly Vector2[] vertex = new Vector2[3];
+		public ReadOnlySpan<Vector2> ConvexVertex()
+		{
+			return new ReadOnlySpan<Vector2>(vertex);
+		}
+		public Vector2 FurthestPoint(Vector2 dir)
+		{
+			Vector2 center = (vertex[0] + vertex[1] + vertex[2]) / 3;
+			Vector2 result = vertex[0];
+			Vector2 Vr = result - center;
+			float d = Vector2.Dot(Vr, dir);
+			for (int i = 1; i < 3; i++)
+			{
+				Vector2 Vi = vertex[i] - center;
+				float di = Vector2.Dot(Vi, dir);
+				if (di > d)
+				{
+					d = di;
+					result = vertex[i];
+				}
+			}
+			return result;
+		}
+		public List<Vector2> GetAxes()
+		{
+			return new List<Vector2>() { vertex[1] - vertex[0], vertex[2] - vertex[1], vertex[0] - vertex[2] };
+		}
+		public void Project(Vector2 axis, out float min, out float max)
+		{
+			min = float.MaxValue;
+			max = float.MinValue;
+			foreach (Vector2 point in vertex)
+			{
+				float projection = Vector2.Dot(point, axis);
+				if (projection < min)
+				{
+					min = projection;
+				}
+				if (projection > max)
+				{
+					max = projection;
+				}
+			}
+		}
+		public static explicit operator NormalConvex2D(Triangle triangle)
+		{
+			return new NormalConvex2D(triangle.ConvexVertex());
+		}
+	}
+	public class Rectangle : IConvex<Vector2>, ISAT<Vector2>, IEPA<Vector2>
+	{
+		private Vector2 leftTop;
+		private float width, height;
+		public Vector2 LeftTop => leftTop;
+		public Vector2 RightTop => leftTop + new Vector2(width, 0);
+		public Vector2 LeftBottom => leftTop + new Vector2(0, height);
+		public Vector2 RightBottom => leftTop + new Vector2(width, height);
+		public Rectangle(Vector2 pos, float width, float height)
+		{
+			leftTop = pos;
+			this.width = width;
+			this.height = height;
+		}
+		public Vector2 FurthestPoint(Vector2 dir)
+		{
+			Vector2 center = leftTop + new Vector2(width, height) / 2;
+			Vector2 result = leftTop;
+			Vector2 Vr = result - center;
+			float d = Vector2.Dot(Vr, dir);
+			foreach (Vector2 v in ConvexVertex())
+			{
+				Vector2 Vi = v - center;
+				float di = Vector2.Dot(Vi, dir);
+				if (di > d)
+				{
+					d = di;
+					result = v;
+				}
+			}
+			return result;
+		}
+		public List<Vector2> GetAxes()
+		{
+			return new List<Vector2>()
+			{
+				RightTop-LeftTop,
+				RightBottom-RightTop,
+				LeftBottom-RightBottom,
+				LeftTop-LeftBottom
+			};
+		}
+		public void Project(Vector2 axis, out float min, out float max)
+		{
+			min = float.MaxValue;
+			max = float.MinValue;
+			foreach (Vector2 point in ConvexVertex())
+			{
+				float projection = Vector2.Dot(point, axis);
+				if (projection < min)
+				{
+					min = projection;
+				}
+				if (projection > max)
+				{
+					max = projection;
+				}
+			}
+		}
+		public ReadOnlySpan<Vector2> ConvexVertex()
+		{
+			Vector2[] array = new Vector2[] { LeftTop, RightTop, RightBottom, LeftBottom };
+			return new ReadOnlySpan<Vector2>(array);
+		}
+		public static explicit operator Microsoft.Xna.Framework.Rectangle(Rectangle rect)
+		{
+			return new Microsoft.Xna.Framework.Rectangle((int)rect.leftTop.X, (int)rect.leftTop.Y, (int)rect.width, (int)rect.height);
+		}
+		public static explicit operator NormalConvex2D(Rectangle rect)
+		{
+			return new NormalConvex2D(new Vector2[] { rect.LeftTop, rect.RightTop, rect.RightBottom, rect.LeftBottom });
+		}
+	}
+}

--- a/Sources/Everglow.Function/Shapes/ShapeCollision.cs
+++ b/Sources/Everglow.Function/Shapes/ShapeCollision.cs
@@ -259,7 +259,7 @@ internal static class ShapeCollision
 				break;
 			}
 		}
-		convex = new NormalConvex2D(polytope.ToArray());
+		convex = NormalConvex2D.Create(polytope.ToArray());
 		return true;
 	}
 	private static bool UpdateSimplex(List<Vector2> polytope, ref Vector2 dir)

--- a/Sources/Everglow.Function/Shapes/ShapeCollision.cs
+++ b/Sources/Everglow.Function/Shapes/ShapeCollision.cs
@@ -202,7 +202,7 @@ internal static class ShapeCollision
 				break;
 			}
 		}
-		convex = new NormalConvex2D(polytope);
+		convex = new NormalConvex2D(polytope.ToArray());
 		return true;
 	}
 	private static bool UpdateSimplex(List<Vector2> polytope, ref Vector2 dir)

--- a/Sources/Everglow.Function/Shapes/ShapeCollision.cs
+++ b/Sources/Everglow.Function/Shapes/ShapeCollision.cs
@@ -1,0 +1,269 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static Everglow.Commons.Shapes.Shape;
+
+namespace Everglow.Commons.Shapes;
+internal static class ShapeCollision
+{
+	#region Normal
+	private static float CrossProduct(Vector2 A, Vector2 B, Vector2 C) => (B.X - A.X) * (C.Y - A.Y) - (B.Y - A.Y) * (C.X - A.X);
+	public static List<Vector2> QuickHull(IEnumerable<Vector2> vs)
+	{
+		if (vs.Count() < 3)
+		{
+			throw new ArgumentException("The count must not be less than 3.");
+		}
+		var sortedVertices = vs.OrderBy(v => v.X).ThenBy(v => v.Y).ToList();
+		var lowerHull = new List<Vector2>();
+		foreach (var v in sortedVertices)
+		{
+			while (lowerHull.Count >= 2 && CrossProduct(lowerHull[^2], lowerHull[^1], v) <= 0)
+			{
+				lowerHull.RemoveAt(lowerHull.Count - 1);
+			}
+			lowerHull.Add(v);
+		}
+		var upperHull = new List<Vector2>();
+		for (int i = sortedVertices.Count - 1; i >= 0; i--)
+		{
+			var v = sortedVertices[i];
+			while (upperHull.Count >= 2 && CrossProduct(upperHull[^2], upperHull[^1], v) <= 0)
+			{
+				upperHull.RemoveAt(upperHull.Count - 1);
+			}
+			upperHull.Add(v);
+		}
+		upperHull.RemoveAt(upperHull.Count - 1);
+		lowerHull.RemoveAt(lowerHull.Count - 1);
+		lowerHull.AddRange(upperHull);
+		return lowerHull;
+	}
+	public static bool Contains(this IConvex<Vector2> convex, Vector2 point)
+	{
+		var vs = convex.ConvexVertex();
+		var len = vs.Length;
+		for (int i = 0; i < len; i++)
+		{
+			Vector2 v1 = vs[i];
+			Vector2 v2 = vs[(i + 1) % len];
+			if (CrossProduct(v1, v2, point) < 0)
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+	public static bool Intersect(Vector2 line1Start, Vector2 line1End, Vector2 line2Start, Vector2 line2End, float precision = 0.000001f)
+	{
+		float
+			x1 = line1Start.X, y1 = line1Start.Y,
+			x2 = line1End.X, y2 = line1End.Y,
+			x3 = line2Start.X, y3 = line1Start.Y,
+			x4 = line2End.X, y4 = line2End.Y;
+		if (Math.Max(x1, x2) < Math.Min(x3, x4) || Math.Max(x3, x4) < Math.Min(x1, x2) ||
+			Math.Max(y1, y2) < Math.Min(y3, y4) || Math.Max(y3, y4) < Math.Min(y1, y2))
+		{
+			return false;
+		}
+		float c1 = (x4 - x3) * (y1 - y3) - (y4 - y3) * (x1 - x3);
+		float c2 = (x4 - x3) * (y2 - y3) - (y4 - y3) * (x2 - x3);
+		float c3 = (x2 - x1) * (y3 - y1) - (y2 - y1) * (x3 - x1);
+		float c4 = (x2 - x1) * (y4 - y1) - (y2 - y1) * (x4 - x1);
+
+		return c1 * c2 <= 0 && c3 * c4 <= 0;
+	}
+	#endregion
+
+	#region SAT
+	public static bool Intersect_SAT(ISAT<Vector2> sat1, ISAT<Vector2> sat2)
+	{
+		List<Vector2> axes = new();
+		// 获取 sat1 和 sat2 的所有分离轴
+		axes.AddRange(sat1.GetAxes());
+		axes.AddRange(sat2.GetAxes());
+		foreach (Vector2 axis in axes)
+		{
+			// 在分离轴上投影 sat1 和 sat2 的区间
+			sat1.Project(axis, out float min1, out float max1);
+			sat2.Project(axis, out float min2, out float max2);
+
+			// 检查投影是否重叠，如果不重叠则碰撞不存在
+			if (max1 < min2 || max2 < min1)
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+	#endregion
+
+	#region GJK
+	public static bool Intersect_GJK(IGJK<Vector2> gjk1, IGJK<Vector2> gjk2)
+	{
+		Vector2 dir = Vector2.UnitX;
+		List<Vector2> simplex = new() { Support(gjk1, gjk2, dir) };
+		dir = Vector2.Normalize(Vector2.Zero - simplex[0]);
+		while (true)
+		{
+			Vector2 A = Support(gjk1, gjk2, dir);
+			if (Vector2.Dot(A, dir) < 0)
+			{
+				return false;
+			}
+			simplex.Add(A);
+			if (HandleSimplex(simplex, ref dir))
+			{
+				return true;
+			}
+		}
+	}
+	private static bool HandleSimplex(List<Vector2> simplex, ref Vector2 dir)
+	{
+		return simplex.Count == 2 ? HandleLine(simplex, ref dir) : HandleTriangle(simplex, ref dir);
+	}
+	private static bool HandleTriangle(List<Vector2> simplex, ref Vector2 dir)
+	{
+		Vector2 C = simplex[^3];
+		Vector2 B = simplex[^2];
+		Vector2 A = simplex[^1];
+		Vector2 AB = Vector2.Normalize(B - A);
+		Vector2 AC = Vector2.Normalize(C - A);
+		Vector2 AO = Vector2.Normalize(Vector2.Zero - A);
+		Vector2 ABperp = TripleProd(AC, AB, AB);
+		Vector2 ACperp = TripleProd(AB, AC, AC);
+		if (Vector2.Dot(ABperp, AO) > 0)
+		{
+			simplex.RemoveAt(simplex.Count - 3);
+			dir = ABperp;
+			return false;
+		}
+		if (Vector2.Dot(ACperp, AO) > 0)
+		{
+			simplex.RemoveAt(simplex.Count - 2);
+			dir = ACperp;
+			return false;
+		}
+		return true;
+	}
+	private static bool HandleLine(List<Vector2> simplex, ref Vector2 dir)
+	{
+		Vector2 B = simplex[^2];
+		Vector2 A = simplex[^1];
+		Vector2 AB = Vector2.Normalize(B - A);
+		Vector2 AO = Vector2.Normalize(Vector2.Zero - A);
+		dir = TripleProd(AB, AO, AB);
+		return false;
+	}
+	private static Vector2 TripleProd(Vector2 v1, Vector2 v2, Vector2 v3)
+	{
+		Vector3 v = Vector3.Cross(Vector3.Cross(new Vector3(v1, 0), new Vector3(v2, 0)), new Vector3(v3, 0));
+		return Vector2.Normalize(new Vector2(v.X, v.Y));
+	}
+	private static Vector2 Support(IGJK<Vector2> gjk1, IGJK<Vector2> gjk2, Vector2 dir)
+	{
+		return gjk1.FurthestPoint(dir) - gjk2.FurthestPoint(-dir);
+	}
+	#endregion
+
+	#region EPA
+	public static bool Intersect_EPA(IEPA<Vector2> epa1, IEPA<Vector2> epa2, out IConvex<Vector2> convex)
+	{
+		convex = null;
+		Vector2 dir = Vector2.UnitX;
+		List<Vector2> simplex = new() { Support(epa1, epa2, dir) };
+		dir = Vector2.Normalize(Vector2.Zero - simplex[0]);
+		while (true)
+		{
+			Vector2 A = Support(epa1, epa2, dir);
+			if (Vector2.Dot(A, dir) < 0)
+			{
+				return false;
+			}
+			simplex.Add(A);
+			if (HandleSimplex(simplex, ref dir))
+			{
+				break;
+			}
+		}
+		List<Vector2> polytope = new(simplex);
+		while (true)
+		{
+			Vector2 support = Support(epa1, epa2, dir);
+			if (Vector2.Dot(support, dir) < 0)
+			{
+				return false;
+			}
+			polytope.Add(support);
+			if (UpdateSimplex(polytope, ref dir))
+			{
+				break;
+			}
+		}
+		convex = new NormalConvex2D(polytope);
+		return true;
+	}
+	private static bool UpdateSimplex(List<Vector2> polytope, ref Vector2 dir)
+	{
+		Vector2 closestPoint = GetClosestPointToOrigin(polytope);
+
+		if (Vector2.Dot(closestPoint, dir) >= 0)
+		{
+			return true;
+		}
+		int index = FindClosestEdge(polytope, closestPoint);
+		Vector2 A = polytope[index];
+		Vector2 B = polytope[(index + 1) % polytope.Count];
+		Vector2 edgeDir = Vector2.Normalize(B - A);
+		dir = TripleProd(edgeDir, A - closestPoint, edgeDir);
+		return false;
+	}
+	private static Vector2 GetClosestPointToOrigin(List<Vector2> polytope)
+	{
+		Vector2 closestPoint = polytope[0];
+		float closestDistSq = closestPoint.LengthSquared();
+
+		for (int i = 1; i < polytope.Count; i++)
+		{
+			Vector2 point = polytope[i];
+			float distSq = point.LengthSquared();
+
+			if (distSq < closestDistSq)
+			{
+				closestPoint = point;
+				closestDistSq = distSq;
+			}
+		}
+
+		return closestPoint;
+	}
+	private static int FindClosestEdge(List<Vector2> polytope, Vector2 closestPoint)
+	{
+		int index = 0;
+		float closestDist = Vector2.DistanceSquared(closestPoint, GetClosestPointOnEdge(polytope[0], polytope[^1], closestPoint));
+
+		for (int i = 0; i < polytope.Count - 1; i++)
+		{
+			Vector2 pointA = polytope[i];
+			Vector2 pointB = polytope[i + 1];
+			float dist = Vector2.DistanceSquared(closestPoint, GetClosestPointOnEdge(pointA, pointB, closestPoint));
+
+			if (dist < closestDist)
+			{
+				index = i;
+				closestDist = dist;
+			}
+		}
+
+		return index;
+	}
+	private static Vector2 GetClosestPointOnEdge(Vector2 pointA, Vector2 pointB, Vector2 closestPoint)
+	{
+		Vector2 edgeDir = Vector2.Normalize(pointB - pointA);
+		float t = Vector2.Dot(closestPoint - pointA, edgeDir);
+		return pointA + t * edgeDir;
+	}
+	#endregion
+}

--- a/Sources/Everglow.Function/Shapes/TriangleWeb_Delaunay.cs
+++ b/Sources/Everglow.Function/Shapes/TriangleWeb_Delaunay.cs
@@ -1,0 +1,566 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Everglow.Commons.Shapes
+{
+	public class TriangleWeb_Delaunay
+	{
+		private static TriangleWeb_Delaunay instance;
+		public static TriangleWeb_Delaunay Instance
+		{
+			get
+			{
+				instance ??= new();
+				return instance;
+			}
+		}
+
+		private int highest = -1;
+		private IList<Vector2> verts;
+		private readonly List<int> indices;
+		private readonly List<TriangleNode> triangles;
+		public TriangleWeb_Delaunay()
+		{
+			triangles = new List<TriangleNode>();
+			indices = new List<int>();
+		}
+		public DelaunayTriangulation CalculateTriangulation(IList<Vector2> verts)
+		{
+			DelaunayTriangulation result = null;
+			CalculateTriangulation(verts, ref result);
+			return result;
+		}
+		public void CalculateTriangulation(IList<Vector2> verts, ref DelaunayTriangulation result)
+		{
+			if (verts == null)
+			{
+				throw new ArgumentNullException("points");
+			}
+			if (verts.Count < 3)
+			{
+				throw new ArgumentException("You need at least 3 points for a triangulation");
+			}
+			triangles.Clear();
+			this.verts = verts;
+			highest = 0;
+			for (int i = 0; i < verts.Count; i++)
+			{
+				if (Higher(highest, i))
+				{
+					highest = i;
+				}
+			}
+			triangles.Add(new TriangleNode(-2, -1, highest));
+			RunBowyerWatson();
+			GenerateResult(ref result);
+			this.verts = null;
+		}
+		public void CalculateTriangulation(IList<Vector2> verts, out List<Triangle> triangles)
+		{
+			triangles = CalculateTriangulation(verts).TransToTriangles();
+		}
+		public void CalculateTriangulation(IList<Vector2> verts, ref DelaunayTriangulation result, out List<Triangle> triangles)
+		{
+			CalculateTriangulation(verts, ref result);
+			triangles = result.TransToTriangles();
+		}
+
+		private bool Higher(int pi0, int pi1)
+		{
+			if (pi0 == -2)
+			{
+				return false;
+			}
+			else if (pi0 == -1)
+			{
+				return true;
+			}
+			else if (pi1 == -2)
+			{
+				return true;
+			}
+			else if (pi1 == -1)
+			{
+				return false;
+			}
+			else
+			{
+				var p0 = verts[pi0];
+				var p1 = verts[pi1];
+				return p0.Y < p1.Y || p0.Y <= p1.Y && p0.X < p1.X;
+			}
+		}
+
+		private void RunBowyerWatson()
+		{
+			for (int i = 0; i < verts.Count; i++)
+			{
+				var pi = i;
+				if (pi == highest)
+				{
+					continue;
+				}
+
+				var ti = FindTriangleNode(pi);
+				var t = triangles[ti];
+				var p0 = t.P0;
+				var p1 = t.P1;
+				var p2 = t.P2;
+				var nti0 = triangles.Count;
+				var nti1 = nti0 + 1;
+				var nti2 = nti0 + 2;
+				var nt0 = new TriangleNode(pi, p0, p1);
+				var nt1 = new TriangleNode(pi, p1, p2);
+				var nt2 = new TriangleNode(pi, p2, p0);
+				nt0.A0 = t.A2;
+				nt1.A0 = t.A0;
+				nt2.A0 = t.A1;
+				nt0.A1 = nti1;
+				nt1.A1 = nti2;
+				nt2.A1 = nti0;
+				nt0.A2 = nti2;
+				nt1.A2 = nti0;
+				nt2.A2 = nti1;
+				t.C0 = nti0;
+				t.C1 = nti1;
+				t.C2 = nti2;
+				triangles[ti] = t;
+				triangles.Add(nt0);
+				triangles.Add(nt1);
+				triangles.Add(nt2);
+				if (nt0.A0 != -1)
+				{
+					LegalizeEdge(nti0, nt0.A0, pi, p0, p1);
+				}
+
+				if (nt1.A0 != -1)
+				{
+					LegalizeEdge(nti1, nt1.A0, pi, p1, p2);
+				}
+
+				if (nt2.A0 != -1)
+				{
+					LegalizeEdge(nti2, nt2.A0, pi, p2, p0);
+				}
+			}
+		}
+
+		private void GenerateResult(ref DelaunayTriangulation result)
+		{
+			result ??= new DelaunayTriangulation();
+			result.Clear();
+			for (int i = 0; i < verts.Count; i++)
+			{
+				result.Vertices.Add(verts[i]);
+			}
+			for (int i = 1; i < triangles.Count; i++)
+			{
+				var t = triangles[i];
+				if (t.IsLeaf && t.IsInner)
+				{
+					result.Triangles.Add(t.P0);
+					result.Triangles.Add(t.P1);
+					result.Triangles.Add(t.P2);
+				}
+			}
+		}
+
+		private void ShuffleIndices()
+		{
+			indices.Clear();
+			indices.Capacity = verts.Count;
+			for (int i = 0; i < verts.Count; i++)
+			{
+				indices.Add(i);
+			}
+			Debug.Assert(indices.Count == verts.Count);
+			for (int i = 0; i < verts.Count - 1; i++)
+			{
+				var j = Main.rand.Next(i, verts.Count);
+				var tmp = indices[i];
+				indices[i] = indices[j];
+				indices[j] = tmp;
+			}
+		}
+
+		private int LeafWithEdge(int ti, int e0, int e1)
+		{
+			Debug.Assert(triangles[ti].HasEdge(e0, e1));
+			while (!triangles[ti].IsLeaf)
+			{
+				var t = triangles[ti];
+				if (t.C0 != -1 && triangles[t.C0].HasEdge(e0, e1))
+				{
+					ti = t.C0;
+				}
+				else if (t.C1 != -1 && triangles[t.C1].HasEdge(e0, e1))
+				{
+					ti = t.C1;
+				}
+				else if (t.C2 != -1 && triangles[t.C2].HasEdge(e0, e1))
+				{
+					ti = t.C2;
+				}
+				else
+				{
+					Debug.Assert(false);
+					throw new Exception("This should never happen");
+				}
+			}
+			return ti;
+		}
+
+		private bool LegalEdge(int k, int l, int i, int j)
+		{
+			Debug.Assert(k != highest && k >= 0);
+			var lMagic = l < 0;
+			var iMagic = i < 0;
+			var jMagic = j < 0;
+			Debug.Assert(!(iMagic && jMagic));
+			if (lMagic)
+			{
+				return true;
+			}
+			else if (iMagic)
+			{
+				Debug.Assert(!jMagic);
+				var p = verts[l];
+				var l0 = verts[k];
+				var l1 = verts[j];
+				return Geom.ToTheLeft(p, l0, l1);
+			}
+			else if (jMagic)
+			{
+				Debug.Assert(!iMagic);
+				var p = verts[l];
+				var l0 = verts[k];
+				var l1 = verts[i];
+				return !Geom.ToTheLeft(p, l0, l1);
+			}
+			else
+			{
+				Debug.Assert(k >= 0 && l >= 0 && i >= 0 && j >= 0);
+				var p = verts[l];
+				var c0 = verts[k];
+				var c1 = verts[i];
+				var c2 = verts[j];
+				Debug.Assert(Geom.ToTheLeft(c2, c0, c1));
+				Debug.Assert(Geom.ToTheLeft(c2, c1, p));
+				return !Geom.InsideCircumcircle(p, c0, c1, c2);
+			}
+		}
+
+		private void LegalizeEdge(int ti0, int ti1, int pi, int li0, int li1)
+		{
+			ti1 = LeafWithEdge(ti1, li0, li1);
+			var t0 = triangles[ti0];
+			var t1 = triangles[ti1];
+			var qi = t1.OtherPoint(li0, li1);
+			Debug.Assert(t0.HasEdge(li0, li1));
+			Debug.Assert(t1.HasEdge(li0, li1));
+			Debug.Assert(t0.IsLeaf);
+			Debug.Assert(t1.IsLeaf);
+			Debug.Assert(t0.P0 == pi || t0.P1 == pi || t0.P2 == pi);
+			Debug.Assert(t1.P0 == qi || t1.P1 == qi || t1.P2 == qi);
+			if (!LegalEdge(pi, qi, li0, li1))
+			{
+				var ti2 = triangles.Count;
+				var ti3 = ti2 + 1;
+				var t2 = new TriangleNode(pi, li0, qi);
+				var t3 = new TriangleNode(pi, qi, li1);
+				t2.A0 = t1.Opposite(li1);
+				t2.A1 = ti3;
+				t2.A2 = t0.Opposite(li1);
+				t3.A0 = t1.Opposite(li0);
+				t3.A1 = t0.Opposite(li0);
+				t3.A2 = ti2;
+				triangles.Add(t2);
+				triangles.Add(t3);
+				var nt0 = triangles[ti0];
+				var nt1 = triangles[ti1];
+				nt0.C0 = ti2;
+				nt0.C1 = ti3;
+				nt1.C0 = ti2;
+				nt1.C1 = ti3;
+				triangles[ti0] = nt0;
+				triangles[ti1] = nt1;
+				if (t2.A0 != -1)
+				{
+					LegalizeEdge(ti2, t2.A0, pi, li0, qi);
+				}
+
+				if (t3.A0 != -1)
+				{
+					LegalizeEdge(ti3, t3.A0, pi, qi, li1);
+				}
+			}
+		}
+
+		private int FindTriangleNode(int pi)
+		{
+			var curr = 0;
+			while (!triangles[curr].IsLeaf)
+			{
+				var t = triangles[curr];
+				curr = t.C0 >= 0 && PointInTriangle(pi, t.C0) ? t.C0 : t.C1 >= 0 && PointInTriangle(pi, t.C1) ? t.C1 : t.C2;
+			}
+			return curr;
+		}
+
+		private bool PointInTriangle(int pi, int ti)
+		{
+			var t = triangles[ti];
+			return ToTheLeft(pi, t.P0, t.P1)
+				&& ToTheLeft(pi, t.P1, t.P2)
+				&& ToTheLeft(pi, t.P2, t.P0);
+		}
+
+		private bool ToTheLeft(int pi, int li0, int li1)
+		{
+			if (li0 == -2)
+			{
+				return Higher(li1, pi);
+			}
+			else if (li0 == -1)
+			{
+				return Higher(pi, li1);
+			}
+			else if (li1 == -2)
+			{
+				return Higher(pi, li0);
+			}
+			else if (li1 == -1)
+			{
+				return Higher(li0, pi);
+			}
+			else
+			{
+				Debug.Assert(li0 >= 0);
+				Debug.Assert(li1 >= 0);
+				return Geom.ToTheLeft(verts[pi], verts[li0], verts[li1]);
+			}
+		}
+
+		private struct TriangleNode
+		{
+			public int P0;
+			public int P1;
+			public int P2;
+			public int C0;
+			public int C1;
+			public int C2;
+			public int A0;
+			public int A1;
+			public int A2;
+			public bool IsLeaf
+			{
+				get
+				{
+					return C0 < 0 && C1 < 0 && C2 < 0;
+				}
+			}
+			public bool IsInner
+			{
+				get
+				{
+					return P0 >= 0 && P1 >= 0 && P2 >= 0;
+				}
+			}
+			public TriangleNode(int P0, int P1, int P2)
+			{
+				this.P0 = P0;
+				this.P1 = P1;
+				this.P2 = P2;
+				C0 = -1;
+				C1 = -1;
+				C2 = -1;
+				A0 = -1;
+				A1 = -1;
+				A2 = -1;
+			}
+			public bool HasEdge(int e0, int e1)
+			{
+				if (e0 == P0)
+				{
+					return e1 == P1 || e1 == P2;
+				}
+				else if (e0 == P1)
+				{
+					return e1 == P0 || e1 == P2;
+				}
+				else if (e0 == P2)
+				{
+					return e1 == P0 || e1 == P1;
+				}
+				return false;
+			}
+			public int OtherPoint(int p0, int p1)
+			{
+				if (p0 == P0)
+				{
+					return p1 == P1 ? P2 : p1 == P2 ? P1 : throw new ArgumentException("p0 and p1 not on triangle");
+				}
+				return p0 == P1
+					? p1 == P0 ? P2 : p1 == P2 ? P0 : throw new ArgumentException("p0 and p1 not on triangle")
+					: p0 == P2
+					? p1 == P0 ? P1 : p1 == P1 ? P0 : throw new ArgumentException("p0 and p1 not on triangle")
+					: throw new ArgumentException("p0 and p1 not on triangle");
+			}
+			public int Opposite(int p)
+			{
+				return p == P0 ? A0 : p == P1 ? A1 : p == P2 ? A2 : throw new ArgumentException("p not in triangle");
+			}
+			public override string ToString()
+			{
+				return IsLeaf
+					? string.Format("TriangleNode({0}, {1}, {2})", P0, P1, P2)
+					: string.Format("TriangleNode({0}, {1}, {2}, {3}, {4}, {5})", P0, P1, P2, C0, C1, C2);
+			}
+		}
+		public class Geom
+		{
+			public static bool AreCoincident(Vector2 a, Vector2 b)
+			{
+				return (a - b).Length() < 0.000001f;
+			}
+			public static bool ToTheLeft(Vector2 p, Vector2 l0, Vector2 l1)
+			{
+				return (l1.X - l0.X) * (p.Y - l0.Y) - (l1.Y - l0.Y) * (p.X - l0.X) >= 0;
+			}
+			public static bool ToTheRight(Vector2 p, Vector2 l0, Vector2 l1)
+			{
+				return !ToTheLeft(p, l0, l1);
+			}
+			public static bool PointInTriangle(Vector2 p, Vector2 c0, Vector2 c1, Vector2 c2)
+			{
+				return ToTheLeft(p, c0, c1)
+					&& ToTheLeft(p, c1, c2)
+					&& ToTheLeft(p, c2, c0);
+			}
+			public static bool InsideCircumcircle(Vector2 p, Vector2 c0, Vector2 c1, Vector2 c2)
+			{
+				var ax = c0.X - p.X;
+				var ay = c0.Y - p.Y;
+				var bx = c1.X - p.X;
+				var by = c1.Y - p.Y;
+				var cx = c2.X - p.X;
+				var cy = c2.Y - p.Y;
+				return
+						(ax * ax + ay * ay) * (bx * cy - cx * by) -
+						(bx * bx + by * by) * (ax * cy - cx * ay) +
+						(cx * cx + cy * cy) * (ax * by - bx * ay)
+				 > 0.000001f;
+			}
+			public static Vector2 RotateRightAngle(Vector2 v)
+			{
+				var x = v.X;
+				v.X = -v.Y;
+				v.Y = x;
+				return v;
+			}
+			public static bool LineLineIntersection(Vector2 p0, Vector2 v3, Vector2 p1, Vector2 v1, out float m0, out float m1)
+			{
+				var det = v3.X * v1.Y - v3.Y * v1.X;
+				if (Math.Abs(det) < 0.001f)
+				{
+					m0 = float.NaN;
+					m1 = float.NaN;
+					return false;
+				}
+				else
+				{
+					m0 = ((p0.Y - p1.Y) * v1.X - (p0.X - p1.X) * v1.Y) / det;
+					m1 = Math.Abs(v1.X) >= 0.001f ? (p0.X + m0 * v3.X - p1.X) / v1.X : (p0.Y + m0 * v3.Y - p1.Y) / v1.Y;
+					return true;
+				}
+			}
+			public static Vector2 LineLineIntersection(Vector2 p0, Vector2 v3, Vector2 p1, Vector2 v1)
+			{
+				return LineLineIntersection(p0, v3, p1, v1, out float m0, out float m1) ? p0 + m0 * v3 : new Vector2(float.NaN, float.NaN);
+			}
+			public static Vector2 CircumcircleCenter(Vector2 c0, Vector2 c1, Vector2 c2)
+			{
+				var mp0 = 0.5f * (c0 + c1);
+				var mp1 = 0.5f * (c1 + c2);
+				var v3 = RotateRightAngle(c0 - c1);
+				var v1 = RotateRightAngle(c1 - c2);
+				LineLineIntersection(mp0, v3, mp1, v1, out float m0, out float m1);
+				return mp0 + m0 * v3;
+			}
+			public static Vector2 TriangleCentroid(Vector2 c0, Vector2 c1, Vector2 c2)
+			{
+				var val = 1.0f / 3.0f * (c0 + c1 + c2);
+				return val;
+			}
+			public static float Area(IList<Vector2> polygon)
+			{
+				var area = 0.0f;
+				var count = polygon.Count;
+				for (int i = 0; i < count; i++)
+				{
+					var j = i == count - 1 ? 0 : i + 1;
+					var p0 = polygon[i];
+					var p1 = polygon[j];
+					area += p0.X * p1.Y - p1.Y * p1.X;
+				}
+				return 0.5f * area;
+			}
+		}
+		public class DelaunayTriangulation
+		{
+			public readonly List<Vector2> Vertices;
+			public readonly List<int> Triangles;
+			public int Count => Triangles.Count / 3;
+			internal DelaunayTriangulation()
+			{
+				Vertices = new List<Vector2>();
+				Triangles = new List<int>();
+			}
+			internal void Clear()
+			{
+				Vertices.Clear();
+				Triangles.Clear();
+			}
+			public bool Verify()
+			{
+				try
+				{
+					for (int i = 0; i < Triangles.Count; i += 3)
+					{
+						var c0 = Vertices[Triangles[i]];
+						var c1 = Vertices[Triangles[i + 1]];
+						var c2 = Vertices[Triangles[i + 2]];
+						for (int j = 0; j < Vertices.Count; j++)
+						{
+							var p = Vertices[j];
+							if (Geom.InsideCircumcircle(p, c0, c1, c2))
+							{
+								return false;
+							}
+						}
+					}
+					return true;
+				}
+				catch
+				{
+					return false;
+				}
+			}
+			public List<Triangle> TransToTriangles()
+			{
+				List<Triangle> result = new();
+				for (int i = 0; i < Triangles.Count; i += 3)
+				{
+					var c0 = Vertices[Triangles[i]];
+					var c1 = Vertices[Triangles[i + 1]];
+					var c2 = Vertices[Triangles[i + 2]];
+					result.Add(new(c0, c1, c2));
+				}
+				return result;
+			}
+		}
+	}
+}

--- a/Sources/Everglow.Function/Shapes/TriangleWeb_Delaunay.cs
+++ b/Sources/Everglow.Function/Shapes/TriangleWeb_Delaunay.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using static Everglow.Commons.Shapes.Shape;
 
 namespace Everglow.Commons.Shapes
 {


### PR DESCRIPTION
基于SAT/GJK的碰撞以及凸形三角剖分
用于较高精度检测实体碰撞（未添加物块判定支持）
性能也许可以优化，但我不建议使用此代码库进行多实体碰撞判定（低精度需求时性价比不如Rectangle的AABB）
具有对于XNA的Rectangle到Shape的Rectangle的显式转换
支持圆形，三角形，矩形，任意点集到常规凸形的转换
支持线与线的碰撞判定
少边图形应优先选择SAT，多边图形在选择GJK
可以通过EPA获取多边形的重合区