### PR TITLE
Hotfix/mod npc sitting

### DIFF
--- a/Sources/Everglow.Function/Utilities/NPCUtils.cs
+++ b/Sources/Everglow.Function/Utilities/NPCUtils.cs
@@ -163,7 +163,6 @@ public class NPCUtils
 				npc.SitDown(npc.Center.ToTileCoordinates(), out npc.direction, out bottom);
 				npc.spriteDirection = npc.direction;
 				npc.velocity *= 0;
-				npc.Bottom = bottom + new Vector2(0, 16);
 				return true;
 			}
 		}
@@ -211,7 +210,7 @@ public class NPCUtils
 		{
 			npc.velocity.Y = -2.5f * obstructionHeight;
 		}
-		else if(checkTile.IsHalfBlock)
+		else if (checkTile.IsHalfBlock)
 		{
 			npc.velocity.Y = -2.5f;
 		}

--- a/Sources/Modules/Myth/Acytaea/NPCs/Acytaea.cs
+++ b/Sources/Modules/Myth/Acytaea/NPCs/Acytaea.cs
@@ -157,6 +157,11 @@ public class Acytaea : VisualNPC
 			{
 				Talking = false;
 			}
+			else if (Sit)
+			{
+				Sit = false;
+				AICoroutines.Enqueue(new Coroutine(Stand(Main.rand.Next(60, 900))));
+			}
 		}
 
 		if (aiMainCount == 0)
@@ -692,7 +697,7 @@ public class Acytaea : VisualNPC
 
 	public override void FindFrame(int frameHeight)
 	{
-		if (Idle)
+		if (Idle || Talking)
 		{
 			if (Sit)
 			{

--- a/Sources/Modules/Myth/Acytaea/NPCs/Acytaea.cs
+++ b/Sources/Modules/Myth/Acytaea/NPCs/Acytaea.cs
@@ -1,5 +1,6 @@
 using Everglow.Commons.Coroutines;
 using Everglow.Myth.Acytaea.Projectiles;
+using Terraria;
 using Terraria.DataStructures;
 using Terraria.GameContent.Bestiary;
 using Terraria.GameContent.Personalities;
@@ -160,7 +161,21 @@ public class Acytaea : VisualNPC
 			else if (Sit)
 			{
 				Sit = false;
-				AICoroutines.Enqueue(new Coroutine(Stand(Main.rand.Next(60, 900))));
+				Idle = true;
+				aiMainCount = 0;
+				AICoroutines.Clear();
+			}
+		}
+
+		if (Sit)
+		{
+			var tile = Main.tile[NPC.Center.ToTileCoordinates()];
+			if (tile == null || !TileID.Sets.CanBeSatOnForNPCs[tile.type])
+			{
+				Sit = false;
+				Idle = true;
+				aiMainCount = 0;
+				AICoroutines.Clear();
 			}
 		}
 


### PR DESCRIPTION
Fix ai for Acytaea:
1. offset when sitting.
2. Acytaea keep sitting when player talk to her.
3. Acytaea keep sitting when the chair is destroyed.