### PR TITLE
Bugfix : Default Biome Icon for Other Mod Biomes

### DIFF
--- a/Sources/Everglow.Function/BiomesText/BiomeLabel.cs
+++ b/Sources/Everglow.Function/BiomesText/BiomeLabel.cs
@@ -111,7 +111,14 @@ public class BiomeLabel : ModSystem
 					ActiveModBiomeCache[modBiome]++;
 					if(ActiveModBiomeCache[modBiome] == timeLag)
 					{
-						NewActiveBiomeQueue.Enqueue(new BiomeData(modBiome.Name, ModContent.Request<Texture2D>(modBiome.BestiaryIcon, ReLogic.Content.AssetRequestMode.ImmediateLoad).Value));
+						if (ModContent.HasAsset(modBiome.BestiaryIcon))
+						{
+							NewActiveBiomeQueue.Enqueue(new BiomeData(modBiome.Name, ModContent.Request<Texture2D>(modBiome.BestiaryIcon, ReLogic.Content.AssetRequestMode.ImmediateLoad).Value));
+						}
+						else
+						{
+							NewActiveBiomeQueue.Enqueue(new BiomeData(modBiome.Name, ModAsset.Cavern.Value));
+						}
 					}			
 				}
 			}


### PR DESCRIPTION
in my playthrough with other mod,  when i enter other mod biome, pop up error occurs because biome icon not found.
i roughly fixed by set default icon and it works (cavern as already working icon)

however i tested self-build github version,  what a great mod