### PR TITLE
fix(Yggdrasil): resolve unexpected zero defense while `Charred` buff is active (#366)

### DIFF
--- a/Sources/Modules/Yggdrasil/Common/YggdrasilGlobalNPC.cs
+++ b/Sources/Modules/Yggdrasil/Common/YggdrasilGlobalNPC.cs
@@ -1,6 +1,23 @@
+using Everglow.Yggdrasil.YggdrasilTown.Buffs;
+
 namespace Everglow.Yggdrasil.Common;
 
 public class YggdrasilGlobalNPC : GlobalNPC
 {
+	public bool CharredActive { get; set; }
+
 	public override bool InstancePerEntity => true;
+
+	public override void ResetEffects(NPC npc)
+	{
+		CharredActive = false;
+	}
+
+	public override void ModifyIncomingHit(NPC npc, ref NPC.HitModifiers modifiers)
+	{
+		if (CharredActive)
+		{
+			modifiers.Defense *= 1 - Charred.DefenseReduction;
+		}
+	}
 }

--- a/Sources/Modules/Yggdrasil/YggdrasilTown/Buffs/Charred.cs
+++ b/Sources/Modules/Yggdrasil/YggdrasilTown/Buffs/Charred.cs
@@ -1,3 +1,4 @@
+using Everglow.Yggdrasil.Common;
 using Terraria.DataStructures;
 
 namespace Everglow.Yggdrasil.YggdrasilTown.Buffs;
@@ -18,12 +19,7 @@ public class Charred : ModBuff
 
 	public override void Update(NPC npc, ref int buffIndex)
 	{
-		npc.defense = (int)((1 - DefenseReduction) * npc.defense);
-		if (npc.defense < 0)
-		{
-			npc.defense = 0;
-		}
-
+		npc.GetGlobalNPC<YggdrasilGlobalNPC>().CharredActive = true;
 		npc.lifeRegen -= LifeRegenReductionFromDot;
 		npc.SetLifeRegenExpectedLossPerSecond(LifeRegenReductionFromDot);
 


### PR DESCRIPTION
Fix commit msg of #366 